### PR TITLE
Replace markdown with HTML for more control over styles

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -1,8 +1,8 @@
-# Android Roadmap
-
-Thunderbird for Android. Follow the roadmap from active work to to future ideas. Timelines may shift as we learn and iterate.
-
-Download Thunderbird for Android - [Google Play Store](https://play.google.com/store/apps/details?id=net.thunderbird.android&hl=en_US), [F-Droid](https://f-droid.org/en/packages/net.thunderbird.android/)
+<div class="product-roadmap-header">
+<h1>Android Roadmap</h1>
+<p>Thunderbird for Android. Follow the roadmap from active work to to future ideas. Timelines may shift as we learn and iterate.</p>
+<p><a href="https://www.thunderbird.net/en-US/thunderbird/all/#select-download-mobile">Download Thunderbird for Android</a></p>
+</div>
 
 ## <i class="ph ph-pulse"></i> Active
 - **Rearchitecture and Core Maintenance** Modernize the source code that we inherited from K9, tackle the most glaring maintenance and stability issues, and restructure the core architecture for faster and easier development.

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,8 +1,8 @@
-# Desktop Roadmap
-
-Thunderbird for Windows, macOS, and Linux. Follow the roadmap from active work to future ideas. Timelines may shift as we learn and iterate.
-
-[Download Thunderbird for desktop](https://www.thunderbird.net/en-US/thunderbird/all/)
+<div class="product-roadmap-header">
+  <h1>Desktop Roadmap</h1>
+  <p>Thunderbird for Windows, macOS, and Linux. Follow the roadmap from active work to future ideas. Timelines may shift as we learn and iterate.</p>
+  <p><a href="https://www.thunderbird.net/en-US/thunderbird/all/#select-download-desktop">Download Thunderbird for desktop</a></p>
+</div>
 
 ## <i class="ph ph-pulse"></i> Active
 - **Exchange (EWS, GraphAPI)** Finalize the work on the Exchange protocol in order to support all versions of Exchange and Microsoft 365, including calendar and address book support.

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -1,6 +1,7 @@
-# iOS Roadmap
-
-Thunderbird for iOS. Follow the roadmap from active work to future ideas. Timelines may shift as we learn and iterate.
+<div class="product-roadmap-header">
+  <h1>iOS Roadmap</h1>
+  <p>Thunderbird for iOS. Follow the roadmap from active work to future ideas. Timelines may shift as we learn and iterate.</p>
+</div>
 
 ## <i class="ph ph-pulse"></i> Active
 - **Account Creation Flow** Implement a full automated and manual setup, including autodiscovery and OAuth.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,6 +1,7 @@
-# Services Roadmap
-
-Thunderbird Pro Services and Infrastructure Support. Follow the roadmap from active work to future ideas. Timelines may change as we learn and iterate.
+<div class="product-roadmap-header">
+  <h1>Services Roadmap</h1>
+  <p>Thunderbird Pro Services and Infrastructure Support. Follow the roadmap from active work to future ideas. Timelines may change as we learn and iterate.</p>
+</div>
 
 ## <i class="ph ph-pulse"></i> Active
 - **Send UI Completion** - Send was the one product we haven't been able to complete UI overhaul work. We don't need to block the rollout for this, but we should work on this to keep it up to par with the other products and create consistency.


### PR DESCRIPTION
:tada:  includes HTML version of per-product header/intro content:

- wraps h1, intro paragraph, and optional link in a div
- adjusts link formatting on android page
- desktop and android download  links jump to relevant section (pending an update those pages)