### PR TITLE
Services Roadmap: update link to ideas

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -1,28 +1,17 @@
 <div class="product-roadmap-header">
   <h1>Services Roadmap</h1>
   <p>Thunderbird Pro Services and Infrastructure Support. Follow the roadmap from active work to future ideas. Timelines may change as we learn and iterate.</p>
+  <p><a href="https://www.ideas.tb.pro">Submit your ideas for Thunderbird Pro</a></p>
 </div>
 
 ## <i class="ph ph-pulse"></i> Active
 - **Send UI Completion** Send was the one product we haven't been able to complete UI overhaul work. We don't need to block the rollout for this, but we should work on this to keep it up to par with the other products and create consistency.
-- **Active Sessions** Give the user a view on their active sessions and allow them to end the session. <bolt-primary-button
-      variant="outline"
-      href="https://ideas.tb.pro/p/show-active-login-sessions">
-      ideas.tb.pro
-    </bolt-primary-button>
+- **Active Sessions** Give the user a view on their active sessions and allow them to end the session.
 
 ## <i class="ph ph-calendar-blank"></i> Planned
-- **MFA Support** Multifactor authentication via TOTP or similar. We didn't get to this in 2025, and it is an essential security feature. <bolt-primary-button
-      variant="outline"
-      href="https://ideas.tb.pro/p/multifactor-authentication">
-      ideas.tb.pro
-    </bolt-primary-button>
+- **MFA Support** Multifactor authentication via TOTP or similar. We didn't get to this in 2025, and it is an essential security feature.
 - **Community Selected Initiative** No doubt the community will have a bunch of great ideas on https://ideas.tb.pro that we can build on. We're making sure we have time to work on one of the top community suggestions that will fit well into the Thunderbird Pro ecosystem.
 - **Integrate Thunderbird Appointment into Pro add-on** As a Pro user, you want to be able to quickly copy your scheduling link when in Thunderbird. Integrate so it can be inserted into emails, or easily copied from the main toolbar.
 - **Improve Pro Add-on Integration** We are shipping an Thunderbird Pro add-on to enable Pro features in Thunderbird desktop. For a low barrier of entry we want to improve integration by using the system add-on or new account add-on mechanism. This allows us to make these features easier to discover and use within Thunderbird.
 - **Thundermail: Webmail** What would an email service be without webmail? We will spend time making the proof of concept more usable, and enable this as an experimental feature for users willing to try new things earyly. The scope will initially be limited to basic folder visibility and message display.
-Webmail will be built with JMAP as a backend, and we need to explore how users can benefit from Webmail while still being encouraged to use end to end encryption and allowing search across folders. <bolt-primary-button
-      variant="outline"
-      href="https://ideas.tb.pro/p/webmail-for-thundermail">
-      ideas.tb.pro
-    </bolt-primary-button>
+Webmail will be built with JMAP as a backend, and we need to explore how users can benefit from Webmail while still being encouraged to use end to end encryption and allowing search across folders.


### PR DESCRIPTION
Remove ideas.tb.pro buttons and replace with a link at the top of the page